### PR TITLE
Run PEP8 on content

### DIFF
--- a/example.py
+++ b/example.py
@@ -167,8 +167,10 @@ def run_example():
 
     # The resource URI for keyvault needs to be specified to get the auth token for the same
     # If you are targeting the Public Azure Cloud, the following vault_resource_uri must be set to 'https://vault.azure.net'
-    vault_resource_uri = mystack_cloud.endpoints.active_directory_resource_id.replace("management", "vault")
-    kv_dp_credentials, subscription_id, mystack_cloud = get_credentials_cert(vault_resource_uri)
+    vault_resource_uri = mystack_cloud.endpoints.active_directory_resource_id.replace(
+        "management", "vault")
+    kv_dp_credentials, subscription_id, mystack_cloud = get_credentials_cert(
+        vault_resource_uri)
 
     # Create a keyvault data plane client using the token provider
     kv_data_client = KeyVaultClient(kv_dp_credentials)


### PR DESCRIPTION
Hello! The Azure documentation team (Content & Learning) is updating existing
Python samples to conform to PEP8. This consists of (only) running `autopep8`
on content. Even if this PR contains only whitespace changes, please accept it.

If you have questions about the rationale behind this change, please email
Microsoft alias `sttramer`.